### PR TITLE
Feat: surrealdb meta functions

### DIFF
--- a/lib/sql/functions/meta.ts
+++ b/lib/sql/functions/meta.ts
@@ -1,0 +1,31 @@
+import { useSurrealValue } from "../../helpers";
+import { SurrealValue } from "../../types";
+import { raw } from "../raw";
+
+/**
+ * Inserts a raw function call for `meta::id()`
+ * 
+ * @param value The value to cast
+ * @returns The raw query
+ */
+function id(value: SurrealValue) {
+	return raw(`meta::id(${useSurrealValue(value)})`);
+}
+
+/**
+ * Inserts a raw function call for `meta::tb()`
+ * 
+ * @param value The value to cast
+ * @returns The raw query
+ */
+function tb(value: SurrealValue) {
+	return raw(`meta::tb(${useSurrealValue(value)})`);
+}
+
+/**
+ * Raw query functions for the category `meta`
+ */
+export const rand = {
+    id,
+    tb,
+};

--- a/lib/sql/functions/meta.ts
+++ b/lib/sql/functions/meta.ts
@@ -25,7 +25,7 @@ function tb(value: SurrealValue) {
 /**
  * Raw query functions for the category `meta`
  */
-export const rand = {
+export const meta = {
     id,
     tb,
 };


### PR DESCRIPTION
This enchantment adds support for surrealdb [meta functions](https://surrealdb.com/docs/surrealql/functions/meta) that are used to get record table or id.

This feature is small this but very useful when working with id's.